### PR TITLE
window.open [APP-200]

### DIFF
--- a/src/renderer/init.js
+++ b/src/renderer/init.js
@@ -31,16 +31,9 @@ if (protocol === `${constants.EXTENSION_PROTOCOL}:`) {
 } else {
   // native window open workaround
   const { ipcRenderer } = require('electron');
-
   const { guestInstanceId, openerId } = process;
-  const hiddenPage = process.argv.includes('--hidden-page');
-  const usesNativeWindowOpen = process.argv.includes('--native-window-open');
 
-  // Any URL that shouldn't be loaded as `nativeWindowOpen` as a popup
-  // should appear here if parent window uses `nativeWindowOpen`
-  const overrideNativeWindowOpenList = ['app.mixmax.com/_oauth/google'];
-
-  require('./window-setup')(window, ipcRenderer, guestInstanceId, openerId, hiddenPage, usesNativeWindowOpen, overrideNativeWindowOpenList);
+  require('./window-setup')(window, ipcRenderer, guestInstanceId, openerId);
   // end workaround
 
   require('./injectors/content-scripts-injector')

--- a/src/renderer/injectors/content-scripts-injector.js
+++ b/src/renderer/injectors/content-scripts-injector.js
@@ -91,16 +91,9 @@ Object.keys(contentScripts).forEach(key => {
     setupContentScript(cs.extensionId, worldId, function (isolatedWorldWindow) {
       // native window open workaround
       const { ipcRenderer } = require('electron');
-
       const { guestInstanceId, openerId } = process;
-      const hiddenPage = process.argv.includes('--hidden-page');
-      const usesNativeWindowOpen = process.argv.includes('--native-window-open');
 
-      // Any URL that shouldn't be loaded as `nativeWindowOpen` as a popup
-      // should appear here if parent window uses `nativeWindowOpen`
-      const overrideNativeWindowOpenList = ['app.mixmax.com/_oauth/google'];
-
-      require('../window-setup')(isolatedWorldWindow, ipcRenderer, guestInstanceId, openerId, hiddenPage, usesNativeWindowOpen, overrideNativeWindowOpenList);
+      require('../window-setup')(isolatedWorldWindow, ipcRenderer, guestInstanceId, openerId);
       // end workaround
 
       for (const script of cs.contentScripts) {


### PR DESCRIPTION
## What is this PR

This PR is intended to fix a problem with message forward between windows context.
With Mixmax we can start the extension correctly but at the onboarding, when the google modal triggers the extension callback, there is an error with`postMessage` that doesn't work because the opener is undefined (ref: https://github.com/electron/electron/issues/16200).

**Important: this `window-setup` is compatible with our current one wich is [here](https://github.com/getstation/browserX/blob/master/app/static/preload/window-open/window-setup.js)**

## How does it work: how to fix the bug, and how it was implemented

This bunch of code polyfill the `window.opener` in the opened window since there is an issue on the electron, change the dispatched event type and add a Mixmax specific code block.

### We use `MessageEvent` instead of `Event`
The small diff is that instead of using `Event` for forwarding `postMessage` we use `MessageEvent`
```js
    event = document.createEvent('Event');
    event.initEvent('message', false, false);
    event.data = message;
    event.origin = sourceOrigin;
    event.source = getOrCreateProxy(ipcRenderer, sourceId);
    window.dispatchEvent(event);
```
is now
```js
     event = new MessageEvent('message', { data: message, origin: sourceOrigin });
     event.source = getOrCreateProxy(ipcRenderer, sourceId);
     win.dispatchEvent(event);
```
We do this because jQuery sucks in the event detection on webapp and extension side. ~~Should be backported in Station and Electron (we spent a lot of time to find the root source of the bug)~~ not a prerequisite for now.

### We add a small chunk for Mixmax
```js
     if (event.data && event.data.method === 'loginFinished') {
       win.location.reload();
     }
```

We added the code block because the event propagation is blocked at the iframe level (iframe CORS origin blocked in Electron).

~~It's a workaround for this Electron issue: https://github.com/electron/electron/issues/9581~~

~~The `window.open` that opens the authentication popup is being called from an `iframe`,  and given preload are not running in `iframe`, the override of `window.open` is not present.~~

~~The `window.open` is triggered from a `webFrame`. The opened window use `postMessage` that forwards to the content-script correctly. The propagation stops to work at the iframe window context where lives a proxy between Mixmax extension, and Mixmax web app doesn't catch the `onMessageEvent`. We tried to override the iframe context with `webFrame.getFrameForSelector` but it is not possible right now since there is no preload for `<iframe>`.~~

## Test instructions

*using Mixmax extension*

### Before this PR

```sh
$ npm run playground:reset
$ npm run start
```

- [ ] At the extension onboarding login the google modal is not closed

### With this PR

```sh
$ npm run playground:reset
$ npm run start
```

- [ ] At the extension onboarding login the google modal is closed after submit and the onboarding start

