### PR TITLE
Fix APIs in frames

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "electron-better-web-request": "^1.0.1",
     "electron-fetch": "^1.3.0",
     "electron-ipc-plus": "^1.3.4",
-    "electron-simple-rpc": "github:alexstrat/electron-simple-rpc",
+    "electron-simple-rpc": "github:alexstrat/electron-simple-rpc#a5195677a2c8a4a9bd67ae5120ee4d7037f88db3",
     "fs-extra": "^7.0.1",
     "mime-types": "^2.1.21",
     "npm-internal": "^1.4.0",


### PR DESCRIPTION
IPC messages were not sent to all frames because, fixed with https://github.com/alexstrat/electron-simple-ipc/commit/b77d28dde40cda76c3da00d26cf42c78a0d2d015 and bumping version.

Fix Apollo DevTools