### PR TITLE
[Fix] Inject CSP into Chrome Extensions requests

### DIFF
--- a/src/browser/engine/protocol.ts
+++ b/src/browser/engine/protocol.ts
@@ -1,19 +1,24 @@
 import { app, protocol } from 'electron';
-import { readFile } from 'fs';
+import { readFileSync, createReadStream } from 'fs';
+import stream from 'stream';
 import { lookup } from 'mime-types';
 import { join } from 'path';
 import { parse } from 'url';
+import ECx from './api';
 
 import { Protocol } from '../../common';
 import { protocolAsScheme } from '../../common/utils';
 import { getExtensionById } from '../chrome-extension';
+
+// tslint:disable-next-line: max-line-length
+const defaultContentSecurityPolicy = 'script-src \'self\' blob: filesystem: chrome-extension-resource:; object-src \'self\' blob: filesystem:;';
 
 protocol.registerStandardSchemes(
   [protocolAsScheme(Protocol.Extension)],
   { secure: true }
 );
 
-const protocolHandler = (
+const protocolHandler = async (
   { url }: Electron.RegisterBufferProtocolRequest,
   callback: Function
 ) => {
@@ -21,38 +26,56 @@ const protocolHandler = (
   if (!hostname || !pathname) return callback();
 
   const extension = getExtensionById(hostname);
-
   if (!extension) return callback();
 
   const { src, backgroundPage: { name, html } } = extension;
+  const headers = {};
 
+  // Hack to get extension ID
+  const splitted = src.split('/');
+  const ecxId = splitted[splitted.length - 2];
+
+  // Set Content Security Policy
+  if (ECx.isLoaded(ecxId)) {
+    const { location: { path } } = await ECx.get(ecxId);
+
+    const manifestPath = join(path, 'manifest.json');
+    const manifest = await readFileSync(manifestPath, 'utf-8');
+
+    const manifestContentSecurityPolicy = JSON.parse(manifest).content_security_policy;
+    const contentSecurityPolicy = manifestContentSecurityPolicy ? manifestContentSecurityPolicy : defaultContentSecurityPolicy;
+
+    headers['content-security-policy'] = contentSecurityPolicy;
+  }
+
+  // ?
   if (`/${name}` === pathname) {
+    headers['content-type'] = 'text/html';
+    const dataStream = new stream.PassThrough();
+    dataStream.end(html);
+
     return callback({
-      mimeType: 'text/html',
-      data: html,
+      statusCode: 200,
+      headers,
+      data: dataStream,
     });
   }
 
   // todo(hugo) check extension permissions
-  readFile(
-    join(src, pathname),
-    (err, content) => {
-      if (err) {
-        return callback(-6);  // FILE_NOT_FOUND
-      }
 
-      const mimeType = lookup(pathname);
+  // Create stream
+  const uri = join(src, pathname);
+  const data = createReadStream(uri);
 
-      if (mimeType) {
-        return callback({
-          mimeType,
-          data: content,
-        });
-      }
+  // Set Mime type
+  const mimeType = lookup(pathname);
+  if (mimeType) headers['content-type'] = mimeType;
 
-      return callback(content);
-    }
-  );
+  return callback({
+    statusCode: 200,
+    headers,
+    data,
+  });
 };
 
 app.on('session-created', (session) => {
@@ -62,7 +85,7 @@ app.on('session-created', (session) => {
     );
   }
 
-  session.protocol.registerBufferProtocol(
+  session.protocol.registerStreamProtocol(
     protocolAsScheme(Protocol.Extension),
     protocolHandler,
     (error: any) => {


### PR DESCRIPTION
## What is this PR
It injects the related Content Security Policies into each Chrome Extension related requests.

## How does it work
It changes the registered protocol from buffer to stream, then check when the request is related to a chrome extension, and if it's the case: inject the related CSP.

## Tests
This is the shady part, as it doesn't seem to happen to everyone.