### PR TITLE
fix: override csp for frame-src

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chrome-extension",
-  "version": "2.0.7",
+  "version": "2.0.8-rc.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -555,6 +555,21 @@
       "dev": true,
       "optional": true
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "1.1.1"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        }
+      }
+    },
     "defined": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
@@ -819,6 +834,36 @@
         "is-arrayish": "0.2.1"
       }
     },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "requires": {
+        "es-to-primitive": "1.2.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.4",
+        "is-regex": "1.0.4",
+        "object-keys": "1.1.1"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        }
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "requires": {
+        "is-callable": "1.1.4",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.2"
+      }
+    },
     "es5-ext": {
       "version": "0.10.49",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.49.tgz",
@@ -1041,6 +1086,11 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -1121,6 +1171,14 @@
         "har-schema": "2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -1143,6 +1201,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "he": {
       "version": "1.1.1",
@@ -1233,6 +1296,16 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
     "is-electron-renderer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz",
@@ -1265,6 +1338,14 @@
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "1.0.3"
+      }
+    },
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
@@ -1274,6 +1355,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "requires": {
+        "has-symbols": "1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -3579,6 +3668,14 @@
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
       "dev": true
     },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "requires": {
+        "define-properties": "1.1.3"
+      }
+    },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
@@ -3853,6 +3950,18 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string.prototype.matchall": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-3.0.1.tgz",
+      "integrity": "sha512-NSiU0ILQr9PQ1SZmM1X327U5LsM+KfDTassJfqN1al1+0iNpKzmQ4BfXOJwRnTEqv8nKJ67mFpqRoPaGWwvy5A==",
+      "requires": {
+        "define-properties": "1.1.3",
+        "es-abstract": "1.13.0",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "regexp.prototype.flags": "1.2.0"
       }
     },
     "string_decoder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -463,6 +463,11 @@
         "yargs": "12.0.5"
       }
     },
+    "content-security-policy-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/content-security-policy-parser/-/content-security-policy-parser-0.1.1.tgz",
+      "integrity": "sha512-JsDgjU0uZJ1IYKGSX5yVlZh20dD2iv0L3peulJbW/FhEl/OvlGF5jdJY6EpuRjZeqg/YZcnZvvUJTJm/BQmulg=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chrome-extension",
-  "version": "2.0.3",
+  "version": "2.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "p-queue": "^3.0.0",
     "querystring": "^0.2.0",
     "recursive-lowercase-json": "^0.2.0",
+    "string.prototype.matchall": "^3.0.1",
     "tmp-promise": "^1.0.5",
     "unzip-crx-3": "^0.2.0",
     "uuid": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chrome-extension",
-  "version": "2.0.8-rc.3",
+  "version": "2.0.8-rc.4",
   "description": "Chrome Extensions Engine for Electron",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chrome-extension",
-  "version": "2.0.5",
+  "version": "2.0.6-rc.1",
   "description": "Chrome Extensions Engine for Electron",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chrome-extension",
-  "version": "2.0.7",
+  "version": "2.0.8-rc.3",
   "description": "Chrome Extensions Engine for Electron",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "electron": ">=4.0.0"
   },
   "devDependencies": {
-    "@types/mime-types": "^2.1.0",
     "@types/fs-extra": "^5.0.4",
     "@types/glob": "^7.1.1",
+    "@types/mime-types": "^2.1.0",
     "@types/mocha": "^5.2.5",
     "@types/tmp": "0.0.33",
     "concurrently": "^4.1.0",
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "capitalize": "^2.0.0",
+    "content-security-policy-parser": "^0.1.1",
     "download-crx": "^1.0.5",
     "electron-better-web-request": "^1.0.1",
     "electron-fetch": "^1.3.0",
@@ -56,5 +57,8 @@
     "unzip-crx-3": "^0.2.0",
     "uuid": "^3.2.1",
     "xml-js": "^1.6.8"
+  },
+  "toolchain": {
+    "node": "10.15.3"
   }
 }

--- a/playground/app.html
+++ b/playground/app.html
@@ -23,14 +23,6 @@
     <webview allowPopups webpreferences="nativeWindowOpen=yes" preload='../lib/src/renderer/init.js'
       src="https://mail.google.com/">
     </webview>
-
-    <webview allowPopups webpreferences="nativeWindowOpen=yes" preload='../lib/src/renderer/init.js'
-      src="https://notion.so/">
-    </webview>
-
-    <webview allowPopups webpreferences="nativeWindowOpen=yes" preload='../lib/src/renderer/init.js'
-      src="https://calendar.google.com/calendar/r">
-    </webview>
   </div>
 </body>
 

--- a/playground/main.js
+++ b/playground/main.js
@@ -51,8 +51,8 @@ app.on('ready', async () => {
     fetcher: { autoUpdate: true, autoUpdateInterval: 1000000 },
   });
 
-  // load React and Gmelius for the fun
-  await ECx.load('dheionainndbbpoacpnopgmnihkcmnkl');
+  // load React and Mixmax for the fun
+  await ECx.load('ocpljaamllnldhepankaeljmeeeghnid');
   await ECx.load('fmkadmapgofadopljbjfkapdkoienihi');
 });
 

--- a/src/browser/engine/protocol.ts
+++ b/src/browser/engine/protocol.ts
@@ -1,15 +1,18 @@
 import { app, protocol } from 'electron';
-import { readFileSync, createReadStream } from 'fs';
-import { Transform, PassThrough } from 'stream';
+import { createReadStream, readFile } from 'fs';
+import { PassThrough } from 'stream';
 import { lookup } from 'mime-types';
-import { join, dirname, normalize } from 'path';
-import { parse, URL } from 'url';
+import { join } from 'path';
+import { parse } from 'url';
+import { promisify } from 'util';
 // @ts-ignore no types
 import matchAll from 'string.prototype.matchall';
 
 import { Protocol } from '../../common';
 import { getExtensionById } from '../chrome-extension';
 import { protocolAsScheme, fromEntries } from '../../common/utils';
+
+const asyncReadFile = promisify(readFile);
 
 /**
  * Protocol.ts
@@ -34,49 +37,6 @@ const defaultContentSecurityPolicy = 'script-src \'self\' blob: filesystem: chro
 // The protocol handler load file into Buffers
 // before transform them into a Stream (expected in callback).
 // Stream callback allow custom headers.
-//
-// Handlable resources are listed in the extension manifest
-// for a navigation from a **web origin** to an extension resource
-// Allowed HTML pages served under `chrome-extension://` protocol
-// can include extension assets that don't need to be whitelisted.
-// Since we didn't know the origin of the requests*, each time we serve
-// a response, we scan the content to whitelist inner resources.
-//
-// * protocol request referrer is always blank.
-// issue: https://github.com/electron/electron/issues/14747
-//
-// refs:
-// https://developer.chrome.com/extensions/manifest/web_accessible_resources
-// AllowExtensionResourceLoad - https://cs.chromium.org/chromium/src/extensions/browser/extension_protocols.cc?l=429
-const whitelistedResourcesFromProtocolServedFiles = new Set();
-
-// Regex to capture the src attribute value for scrips, stylesheets...
-const resourceLinkRegex = /src\s*=\s*['"](.+?)['"]/g;
-
-const captureWhitelistableResourcesFromProtocolServedFile = (pathname: string) =>
-  new Transform({
-    transform(chunk: any, _encoding: any, cb: Function) {
-      const linksAllowed = matchAll(chunk.toString('utf8'), resourceLinkRegex);
-      const directory = dirname(pathname);
-
-      for (const [, link] of linksAllowed) {
-        try {
-          const isUrl = new URL(link);
-          if (isUrl) break;
-        } catch (e) { }
-
-        const fullPath = join(directory, normalize(link));
-
-        if (!whitelistedResourcesFromProtocolServedFiles.has(fullPath)) {
-          whitelistedResourcesFromProtocolServedFiles.add(fullPath);
-        }
-      }
-
-      // tslint:disable-next-line: no-invalid-this
-      this.push(chunk);
-      cb();
-    },
-  });
 
 const protocolHandler = async (
   { url }: Electron.RegisterBufferProtocolRequest,
@@ -91,7 +51,7 @@ const protocolHandler = async (
   const { src, backgroundPage: { name, html } } = extension;
 
   const manifestPath = join(src, 'manifest.json');
-  const manifestFile = await readFileSync(manifestPath, 'utf-8');
+  const manifestFile = await asyncReadFile(manifestPath, 'utf-8');
   const manifest = JSON.parse(manifestFile);
 
   const headers = new Map();
@@ -121,7 +81,6 @@ const protocolHandler = async (
     headers.set('content-type', 'text/html');
 
     const backgroundPageData = (new PassThrough())
-      .pipe(captureWhitelistableResourcesFromProtocolServedFile(pathname))
       .end(html);
 
     return callback({
@@ -131,22 +90,8 @@ const protocolHandler = async (
     });
   }
 
-  const accessibleResources = manifest.web_accessible_resources
-    .map((r: any) => `/${r}`); // accessibles ressources are relatives to the extension folder. Make them absolut to play with URL Node module
-
-  const isResourceAccessible = accessibleResources.includes(pathname) ||
-    whitelistedResourcesFromProtocolServedFiles.has(pathname);
-
-  if (!isResourceAccessible) {
-    return callback({
-      statusCode: 403,
-      headers: fromEntries(headers),
-    });
-  }
-
   const uri = join(src, pathname);
-  const data = createReadStream(uri)
-    .pipe(captureWhitelistableResourcesFromProtocolServedFile(pathname));
+  const data = createReadStream(uri);
 
   const mimeType = lookup(pathname);
   if (mimeType) headers.set('content-type', mimeType);

--- a/src/browser/engine/protocol.ts
+++ b/src/browser/engine/protocol.ts
@@ -63,15 +63,15 @@ const protocolHandler = async (
     });
   }
 
-  const accessibleResources = manifest.web_accessible_resources;
-  const isResourceAccessible = accessibleResources.includes(pathname.replace(/^\/+/g, '')); // remove leading slash for relative url
+  // const accessibleResources = manifest.web_accessible_resources;
+  // const isResourceAccessible = accessibleResources.includes(pathname.replace(/^\/+/g, '')); // remove leading slash for relative url
 
-  if (!isResourceAccessible) {
-    return callback({
-      statusCode: 403,
-      headers,
-    });
-  }
+  // if (!isResourceAccessible) {
+  //   return callback({
+  //     statusCode: 403,
+  //     headers,
+  //   });
+  // }
 
   // Create file stream
   const uri = join(src, pathname);

--- a/src/browser/engine/protocol.ts
+++ b/src/browser/engine/protocol.ts
@@ -11,6 +11,8 @@ import { protocolAsScheme } from '../../common/utils';
 
 import ECx from './api';
 
+// match Chromium kDefaultContentSecurityPolicy
+// https://cs.chromium.org/chromium/src/extensions/common/manifest_handlers/csp_info.cc?l=31
 // tslint:disable-next-line: max-line-length
 const defaultContentSecurityPolicy = 'script-src \'self\' blob: filesystem: chrome-extension-resource:; object-src \'self\' blob: filesystem:;';
 
@@ -30,7 +32,10 @@ const protocolHandler = async (
   if (!extension) return callback();
 
   const { src, backgroundPage: { name, html } } = extension;
+
   const headers = {};
+
+  headers['access-control-allow-origin'] = '*';
 
   // Todo : Hack to get extension ID,
   // revert to hostname when this (https://github.com/getstation/electron-chrome-extension/commit/8f8d37e13c47611ce9c8b184775a68fa52fc883d) is reverted too

--- a/src/browser/engine/protocol.ts
+++ b/src/browser/engine/protocol.ts
@@ -9,7 +9,16 @@ import { Protocol } from '../../common';
 import { getExtensionById } from '../chrome-extension';
 import { protocolAsScheme } from '../../common/utils';
 
-// Match Chromium kDefaultContentSecurityPolicy
+/*
+Protocol.ts
+
+Everything related to `chrome-extension://` protocol goes here
+
+- Register protocol
+- Handle and serve extension web resources and background page
+*/
+
+// defaultContentSecurityPolicy match Chromium kDefaultContentSecurityPolicy
 // https://cs.chromium.org/chromium/src/extensions/common/manifest_handlers/csp_info.cc?l=31
 // tslint:disable-next-line: max-line-length
 const defaultContentSecurityPolicy = 'script-src \'self\' blob: filesystem: chrome-extension-resource:; object-src \'self\' blob: filesystem:;';
@@ -20,9 +29,11 @@ const defaultContentSecurityPolicy = 'script-src \'self\' blob: filesystem: chro
 );
 
 const protocolHandler = async (
-  { url }: Electron.RegisterBufferProtocolRequest,
+  h: Electron.RegisterBufferProtocolRequest,
   callback: Function
 ) => {
+  console.log(h);
+  const { url } = h;
   const { hostname, pathname } = parse(url);
   if (!hostname || !pathname) return callback();
 
@@ -65,6 +76,11 @@ const protocolHandler = async (
 
   // const accessibleResources = manifest.web_accessible_resources;
   // const isResourceAccessible = accessibleResources.includes(pathname.replace(/^\/+/g, '')); // remove leading slash for relative url
+
+  // check inner related scripts and assets
+
+  // webRequest doesn't work
+  // we don't have the referrer
 
   // if (!isResourceAccessible) {
   //   return callback({

--- a/src/browser/engine/webRequest.ts
+++ b/src/browser/engine/webRequest.ts
@@ -98,7 +98,8 @@ app.on(
         //
         // `chrome-extension://` is registered as privilegied
         // with `webFrame.registerURLSchemeAsPrivileged()`
-        // but added iFrames don't bypass top frame CSP frame-src policy
+        // but added iFrames with extension protocol
+        // don't bypass top frame CSP frame-src policy
         //
         // ref: https://bugs.chromium.org/p/chromium/issues/detail?id=408932#c35
         //
@@ -140,7 +141,7 @@ app.on(
 
           headers.set(cspHeaderKey, [newPolicies]);
         }
-        // End override
+        // End override CSP iframe-src policy
 
         const accessControlAllowOrigin = responseheaders['access-control-allow-origin'] || [];
         const allowedOriginIsWildcard = accessControlAllowOrigin.includes('*');

--- a/src/browser/engine/webRequest.ts
+++ b/src/browser/engine/webRequest.ts
@@ -2,9 +2,33 @@ import { app, webContents } from 'electron';
 import enhanceWebRequest from 'electron-better-web-request';
 // @ts-ignore
 import recursivelyLowercaseJSONKeys from 'recursive-lowercase-json';
+// @ts-ignore
+import parse from 'content-security-policy-parser';
 
 import { Protocol } from '../../common';
 import { fromEntries } from '../../common/utils';
+
+/**
+ * Convert object of policies into content security policy heder value
+ *
+ * @example
+ * {
+ * 'default-src': ["'self'"],
+ * 'script-src': ["'unsafe-eval'", 'scripts.com'],
+ * 'object-src': [],
+ * 'style-src': ['styles.biz']
+ * } => "default-src 'self'; script-src 'unsafe-eval' scripts.com; object-src; style-src styles.biz"
+ *
+ * @param { [name: string]: string[] } policies policies as object
+ * @return {string} the stringified policies
+ */
+const stringify = (policies: { [name: string]: string[] }): string =>
+  Object.entries(policies)
+    .map(
+      ([name, value]: [string, string[]]) =>
+        `${name} ${value.join(' ')}`
+    )
+    .join(';');
 
 const requestIsXhrOrSubframe = (details: any) => {
   const { resourcetype } = details;
@@ -125,27 +149,35 @@ app.on(
 
         const cspHeaderKey = 'content-security-policy';
         const cspPolicyKey = 'frame-src';
-        const cspPolicyDelimiter = ';';
-        const cspDirective: string | undefined = (responseheaders[cspHeaderKey] || [])[0];
+        const cspDirective: string = (responseheaders[cspHeaderKey] || [])[0];
 
         if (cspDirective) {
-          const policies = cspDirective.split(cspPolicyDelimiter);
+          const policies = parse(cspDirective);
+          const frameSrcPolicy = policies[cspPolicyKey];
 
-          const unmodifiedPolicies = policies.filter((p: string) => !p.includes(cspPolicyKey));
+          if (frameSrcPolicy) {
+            const policiesWithOverride = {
+              ...policies,
+              [cspPolicyKey]: [...frameSrcPolicy, Protocol.Extension],
+            };
 
-          const modifiedFrameSrcPolicies = policies
-            .filter((p: string) => p.includes(cspPolicyKey))
-            .map((p: string) => `${p} ${Protocol.Extension}`);
-
-          const newPolicies = unmodifiedPolicies.concat(modifiedFrameSrcPolicies).join(`${cspPolicyDelimiter} `);
-
-          headers.set(cspHeaderKey, [newPolicies]);
+            headers.set(cspHeaderKey, [stringify(policiesWithOverride)]);
+          }
         }
         // End override CSP iframe-src policy
 
         const accessControlAllowOrigin = responseheaders['access-control-allow-origin'] || [];
         const allowedOriginIsWildcard = accessControlAllowOrigin.includes('*');
 
+        // Code block for bypass preflight CORS check like Wavebox is doing it
+        // `chrome-extension://` requests doesn't bypass CORS
+        // check like in Chromium
+        //
+        // refs:
+        // https://fetch.spec.whatwg.org/#cors-check
+        // https://cs.chromium.org/chromium/src/extensions/common/cors_util.h?rcl=faf5cf5cb5985875dedd065d852b35a027e50914&l=21
+        // https://github.com/wavebox/waveboxapp/blob/09f791314e1ecc808cbbf919ac65e5f6dda785bd/src/app/src/Extensions/Chrome/CRExtensionRuntime/CRExtensionBackgroundPage.js#L195
+        // todo(hugo): find a better and understandable solution
         if (requestIsForExtension(formattedDetails)
           || allowedOriginIsWildcard) {
           headers.set('access-control-allow-credentials', ['true']);

--- a/src/browser/engine/webRequest.ts
+++ b/src/browser/engine/webRequest.ts
@@ -102,7 +102,6 @@ app.on(
         //
         // ref: https://bugs.chromium.org/p/chromium/issues/detail?id=408932#c35
         //
-        // -- Flow
         //
         // * Protocol `chrome-extension://` is considered trustworthy
         // ref: https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy
@@ -124,17 +123,17 @@ app.on(
         // https://cs.chromium.org/chromium/src/extensions/common/csp_validator.cc?l=256
 
         const cspHeaderKey = 'content-security-policy';
-        const cspDirectiveKey = 'frame-src';
+        const cspPolicyKey = 'frame-src';
         const cspPolicyDelimiter = ';';
-        const cspDirective: string | undefined = (responseheaders[cspDirectiveKey] || [])[0];
+        const cspDirective: string | undefined = (responseheaders[cspHeaderKey] || [])[0];
 
         if (cspDirective) {
           const policies = cspDirective.split(cspPolicyDelimiter);
 
-          const unmodifiedPolicies = policies.filter((p: string) => !p.includes(cspDirectiveKey));
+          const unmodifiedPolicies = policies.filter((p: string) => !p.includes(cspPolicyKey));
 
           const modifiedFrameSrcPolicies = policies
-            .filter((p: string) => p.includes(cspDirectiveKey))
+            .filter((p: string) => p.includes(cspPolicyKey))
             .map((p: string) => `${p} ${Protocol.Extension}`);
 
           const newPolicies = unmodifiedPolicies.concat(modifiedFrameSrcPolicies).join(`${cspPolicyDelimiter} `);

--- a/src/browser/engine/webRequest.ts
+++ b/src/browser/engine/webRequest.ts
@@ -102,7 +102,7 @@ app.on(
         // don't bypass top frame CSP frame-src policy
         //
         // ref: https://bugs.chromium.org/p/chromium/issues/detail?id=408932#c35
-        //
+        // todo: remove this block since Electron 5 fix the problem
         //
         // * Protocol `chrome-extension://` is considered trustworthy
         // ref: https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy

--- a/src/browser/engine/webRequest.ts
+++ b/src/browser/engine/webRequest.ts
@@ -4,6 +4,7 @@ import enhanceWebRequest from 'electron-better-web-request';
 import recursivelyLowercaseJSONKeys from 'recursive-lowercase-json';
 
 import { Protocol } from '../../common';
+import { fromEntries } from '../../common/utils';
 
 const requestIsXhrOrSubframe = (details: any) => {
   const { resourcetype } = details;
@@ -91,34 +92,73 @@ app.on(
         const formattedDetails = recursivelyLowercaseJSONKeys(details);
         const { id, responseheaders } = formattedDetails;
 
+        const headers = new Map<string, string[]>(Object.entries(responseheaders));
+
+        // Override Content Security Policy Header
+        //
+        // `chrome-extension://` is registered as privilegied
+        // with `webFrame.registerURLSchemeAsPrivileged()`
+        // but added iFrames don't bypass top frame CSP frame-src policy
+        //
+        // ref: https://bugs.chromium.org/p/chromium/issues/detail?id=408932#c35
+        //
+        // -- Flow
+        //
+        // * Protocol `chrome-extension://` is considered trustworthy
+        // ref: https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy
+        //
+        // * Protocol can bypass secure context check
+        // ref: //src/chrome/common/secure_origin_whitelist.cc
+        // https://cs.chromium.org/chromium/src/chrome/common/secure_origin_whitelist.cc?l=16
+        //
+        // * Protocol added to the Renderer Web Secure Context Safelist
+        // ref: //src/chrome/renderer/chrome_content_renderer_client.cc
+        // https://cs.chromium.org/chromium/src/chrome/renderer/chrome_content_renderer_client.cc?l=428
+        //
+        // * Protocol should bypass CSP check
+        // ref: //src/third_party/blink/renderer/core/frame/csp/content_security_policy.cc?l=706
+        // https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/frame/csp/content_security_policy.cc?l=1557
+        //
+        // * Secure Directive Values
+        // ref: //src/extensions/common/csp_validator.cc
+        // https://cs.chromium.org/chromium/src/extensions/common/csp_validator.cc?l=256
+
+        const cspHeaderKey = 'content-security-policy';
+        const cspDirectiveKey = 'frame-src';
+        const cspPolicyDelimiter = ';';
+        const cspDirective: string | undefined = (responseheaders[cspDirectiveKey] || [])[0];
+
+        if (cspDirective) {
+          const policies = cspDirective.split(cspPolicyDelimiter);
+
+          const unmodifiedPolicies = policies.filter((p: string) => !p.includes(cspDirectiveKey));
+
+          const modifiedFrameSrcPolicies = policies
+            .filter((p: string) => p.includes(cspDirectiveKey))
+            .map((p: string) => `${p} ${Protocol.Extension}`);
+
+          const newPolicies = unmodifiedPolicies.concat(modifiedFrameSrcPolicies).join(`${cspPolicyDelimiter} `);
+
+          headers.set(cspHeaderKey, [newPolicies]);
+        }
+        // End override
+
         const accessControlAllowOrigin = responseheaders['access-control-allow-origin'] || [];
         const allowedOriginIsWildcard = accessControlAllowOrigin.includes('*');
 
         if (requestIsForExtension(formattedDetails)
           || allowedOriginIsWildcard) {
-          const modifiedHeaders = {
-            'access-control-allow-credentials': ['true'],
-            'access-control-allow-origin': [requestsOrigins.get(id)],
-          };
-          requestsOrigins.delete(id);
-
-          return callback({
-            cancel: false,
-            responseHeaders: {
-              ...responseheaders,
-              ...modifiedHeaders,
-            },
-          });
+          headers.set('access-control-allow-credentials', ['true']);
+          headers.set('access-control-allow-origin', [requestsOrigins.get(id)!]);
+        } else {
+          headers.set('access-control-allow-credentials', ['true']);
         }
 
         requestsOrigins.delete(id);
 
         callback({
           cancel: false,
-          responseHeaders: {
-            ...responseheaders,
-            'access-control-allow-credentials': ['true'],
-          },
+          responseHeaders: fromEntries(headers),
         });
       },
       {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,3 +1,7 @@
 import { Protocol } from './index';
 
 export const protocolAsScheme = (protocol: Protocol) => protocol.slice(0, -1);
+
+// todo(hugo | electron 5) remove for Object.fromEntries()
+export const fromEntries = (iterable: any) => [...iterable]
+  .reduce((obj, { 0: key, 1: val }) => Object.assign(obj, { [key]: val }), {});

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,10 +67,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.14.tgz#c03b6380c5c301be0499ecd143b99b76ebe45678"
   integrity sha512-0rVcFRhM93kRGAU88ASCjX9Y3FWDCh+33G5Z5evpKOea4xcpLqDGwmo64+DjgaSezTN5j9KdnUzvxhOw7fNciQ==
 
-"@types/node@^8.0.24":
-  version "8.10.38"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.38.tgz#e05c201a668492e534b48102aca0294898f449f6"
-  integrity sha512-EibsnbJerd0hBFaDjJStFrVbVBAtOy4dgL8zZFw0uOvPqzBAX59Ci8cgjg3+RgJIWhsB5A4c+pi+D4P9tQQh/A==
+"@types/node@^10.12.18":
+  version "10.14.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.6.tgz#9cbfcb62c50947217f4d88d4d274cc40c22625a9"
+  integrity sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==
 
 "@types/tmp@0.0.33":
   version "0.0.33"
@@ -532,6 +532,11 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
+content-security-policy-parser@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/content-security-policy-parser/-/content-security-policy-parser-0.1.1.tgz#aab52f88264f316d909919d281a13dbf042b293c"
+  integrity sha512-JsDgjU0uZJ1IYKGSX5yVlZh20dD2iv0L3peulJbW/FhEl/OvlGF5jdJY6EpuRjZeqg/YZcnZvvUJTJm/BQmulg==
+
 core-js@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.3.0.tgz#fab83fbb0b2d8dc85fa636c4b9d34c75420c6d65"
@@ -646,6 +651,13 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+define-properties@^1.1.2, define-properties@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
+
 defined@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-0.0.0.tgz#f35eea7d705e933baf13b2f03b3f83d921403b3e"
@@ -710,10 +722,10 @@ editor@~1.0.0:
   resolved "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz#60c7f87bd62bcc6a894fa8ccd6afb7823a24f742"
   integrity sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=
 
-electron-better-web-request@^1.0.0-rc5:
-  version "1.0.0-rc5"
-  resolved "https://registry.yarnpkg.com/electron-better-web-request/-/electron-better-web-request-1.0.0-rc5.tgz#782c35d2ed21cda4ae28b0185db435a119810435"
-  integrity sha512-TWi2bflz0iR6vzkRZmpYpFjVJFb8586G3ENm1SItY1D5bsG3JfoWCjtVp5XqZ+XgA3659TP9gvYyl83zRruaVw==
+electron-better-web-request@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/electron-better-web-request/-/electron-better-web-request-1.0.1.tgz#9c7ccf88499cc8b17f9bffd3f33a01fc1e70282a"
+  integrity sha512-euwLeL82k6fbVODfH5Uz9c4BN047/XyYKfsZcaFhdWfqx05JPu2J0xE7nciJ/1Bb0sTClU1FDLW5H2zQWBB5Gw==
   dependencies:
     url-match-patterns "^0.2.0"
     uuid "^3.3.2"
@@ -763,14 +775,14 @@ electron-platform@^1.2.0:
   resolved "https://registry.yarnpkg.com/electron-platform/-/electron-platform-1.2.0.tgz#2fc70bce53fb732ec81769bd6c48e10c40a551aa"
   integrity sha1-L8cLzlP7cy7IF2m9bEjhDEClUao=
 
-electron-process-manager@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/electron-process-manager/-/electron-process-manager-0.6.0.tgz#56438818bdbdd2c5413df7caac53f116844ae3fb"
-  integrity sha512-RulHKnDXPLlwGIuGGOjVTT8ChxWbL1q0rh2LCuuhw5qM/xktp2dpyhN2VgxWFxqf4Nc6ZgUuZDtmGAmkDP0IWQ==
+electron-process-manager@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/electron-process-manager/-/electron-process-manager-0.7.1.tgz#fb53f6f80f1d0b10d32da758bc8bc9013751a5e0"
+  integrity sha512-GE7Sok7IfObhVPqx7n+wVBpdFxVvR/ySa56sLsTT4rnYKBFDWtdrVMiXgKjhHjxsxO59Y+piXT6QonamrQFWeA==
   dependencies:
-    electron-process-reporter "^1.2.1"
+    electron-process-reporter "^1.4.0"
 
-electron-process-reporter@^1.2.1:
+electron-process-reporter@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/electron-process-reporter/-/electron-process-reporter-1.4.0.tgz#74bfa7f0dd9791307ca9263ad7ce7bca5447f267"
   integrity sha512-zI5IV7zplV2eHznNbeYtMwATVqXO+g9i2ChpurvGTvExA/rpi7BdSrp38bsTz5tjJLLTz9LmzeSt85uIZ051Qw==
@@ -780,16 +792,21 @@ electron-process-reporter@^1.2.1:
     pidusage "2.0.16"
     rxjs "^5.5.6"
 
-"electron-simple-ipc@github:alexstrat/electron-simple-ipc#32943d9d442436922aab3d5b3c14ebb46c4ea41d":
-  version "1.1.0"
-  resolved "https://codeload.github.com/alexstrat/electron-simple-ipc/tar.gz/32943d9d442436922aab3d5b3c14ebb46c4ea41d"
+electron-simple-ipc@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/electron-simple-ipc/-/electron-simple-ipc-1.0.2.tgz#8c875119922a5231b60e0aaedb793c069bdaa78a"
+  integrity sha1-jIdRGZIqUjG2Dgqu23k8Bpvap4o=
 
-"electron-simple-rpc@github:alexstrat/electron-simple-rpc":
+"electron-simple-ipc@github:alexstrat/electron-simple-ipc#85b6336dd229c7971609f6f371b624059f594745":
   version "1.1.1"
-  resolved "https://codeload.github.com/alexstrat/electron-simple-rpc/tar.gz/54240bcc5f0454d6e46bc0d3e6c80b219b71939c"
+  resolved "https://codeload.github.com/alexstrat/electron-simple-ipc/tar.gz/85b6336dd229c7971609f6f371b624059f594745"
+
+"electron-simple-rpc@github:alexstrat/electron-simple-rpc#a5195677a2c8a4a9bd67ae5120ee4d7037f88db3":
+  version "1.1.2"
+  resolved "https://codeload.github.com/alexstrat/electron-simple-rpc/tar.gz/a5195677a2c8a4a9bd67ae5120ee4d7037f88db3"
   dependencies:
     bluebird "^3.5.0"
-    electron-simple-ipc "github:alexstrat/electron-simple-ipc#32943d9d442436922aab3d5b3c14ebb46c4ea41d"
+    electron-simple-ipc "github:alexstrat/electron-simple-ipc#85b6336dd229c7971609f6f371b624059f594745"
     lodash "^4.17.4"
     uuid "^3.0.1"
 
@@ -800,12 +817,12 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@^3.0.5:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-3.1.1.tgz#983492f0eb25740d1ba1da47712b16139ebc6d17"
-  integrity sha512-ZamfKY9xp8P6/prtBbhOoOsdCaqyArr7GOmgJuBgWY95ZW5nJVP5aA5lLTh8IeVSW1/IM1KyKYPTrTS/RGercQ==
+electron@^4.0.4:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-4.2.1.tgz#e1ca9b6cecbce9960bfc25a4e1221a99bd80961f"
+  integrity sha512-v1pwY6PQ+ITVkV/QGgEAEjoBGnPIuut80M+GseWkLcIJ+mIN3xbpuhd1v6arJ1XV7H6waNwjtIFgGSmVWWNRhw==
   dependencies:
-    "@types/node" "^8.0.24"
+    "@types/node" "^10.12.18"
     electron-download "^4.1.0"
     extract-zip "^1.0.3"
 
@@ -827,6 +844,27 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.12.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
+  integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-keys "^1.0.12"
+
+es-to-primitive@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.45, es5-ext@^0.10.9, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
   version "0.10.46"
@@ -1092,6 +1130,11 @@ fstream@^1.0.0, fstream@^1.0.2, fstream@~1.0.10:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
 gauge@~1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-1.2.7.tgz#e9cec5483d3d4ee0ef44b60a7d99e4935e136d93"
@@ -1312,10 +1355,22 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
+
+has@^1.0.1, has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 hawk@~3.1.3:
   version "3.1.3"
@@ -1458,6 +1513,16 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-callable@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
+
 is-electron-renderer@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz#a469d056f975697c58c98c6023eb0aa79af895a2"
@@ -1513,6 +1578,13 @@ is-redirect@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
   integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
+  dependencies:
+    has "^1.0.1"
+
 is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
@@ -1522,6 +1594,13 @@ is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
+  dependencies:
+    has-symbols "^1.0.0"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -2190,6 +2269,11 @@ object-inspect@~0.4.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-0.4.0.tgz#f5157c116c1455b243b06ee97703392c5ad89fec"
   integrity sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w=
 
+object-keys@^1.0.12:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
 object-keys@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
@@ -2611,6 +2695,11 @@ realize-package-specifier@~3.0.1:
     dezalgo "^1.0.1"
     npm-package-arg "^4.1.1"
 
+recursive-lowercase-json@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/recursive-lowercase-json/-/recursive-lowercase-json-0.2.0.tgz#b5d8cd9723a9eec23a8ec7bcafbdba033dc340c0"
+  integrity sha1-tdjNlyOp7sI6jse8r726Az3DQMA=
+
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -2623,6 +2712,13 @@ reflect-metadata@^0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.12.tgz#311bf0c6b63cd782f228a81abe146a2bfa9c56f2"
   integrity sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A==
+
+regexp.prototype.flags@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz#6b30724e306a27833eeb171b66ac8890ba37e41c"
+  integrity sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==
+  dependencies:
+    define-properties "^1.1.2"
 
 repeating@^2.0.0:
   version "2.0.1"
@@ -2963,6 +3059,17 @@ string-width@^1.0.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string.prototype.matchall@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-3.0.1.tgz#5a9e0b64bcbeb336aa4814820237c2006985646d"
+  integrity sha512-NSiU0ILQr9PQ1SZmM1X327U5LsM+KfDTassJfqN1al1+0iNpKzmQ4BfXOJwRnTEqv8nKJ67mFpqRoPaGWwvy5A==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.12.0"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    regexp.prototype.flags "^1.2.0"
 
 string_decoder@~0.10.x:
   version "0.10.31"
@@ -3336,10 +3443,10 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
-unzip-crx@^0.2.0:
+unzip-crx-3@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/unzip-crx/-/unzip-crx-0.2.0.tgz#4c0baa8bdac756256754beca7843c13d7b858c18"
-  integrity sha1-TAuqi9rHViVnVL7KeEPBPXuFjBg=
+  resolved "https://registry.yarnpkg.com/unzip-crx-3/-/unzip-crx-3-0.2.0.tgz#d5324147b104a8aed9ae8639c95521f6f7cda292"
+  integrity sha512-0+JiUq/z7faJ6oifVB5nSwt589v1KCduqIJupNVDoWSXZtWDmjDGO3RAEOvwJ07w90aoXoP4enKsR7ecMrJtWQ==
   dependencies:
     jszip "^3.1.0"
     mkdirp "^0.5.1"


### PR DESCRIPTION
### What is this PR

- Fixed a bug about CSP: trusted protocol `chrome-extension://` is not bypassed in CSP check at the iframe document level, so we add it to the `frame-src` to the directive in the Content Security Policy header
More [here](https://github.com/getstation/electron-chrome-extension/pull/50/files#diff-0e01e923692aaf451bdd7213b7ebfa4dR97)
- ~Revamped the protocol handler and added verification for [web accessible resources](https://developer.chrome.com/extensions/manifest/web_accessible_resources)~

### How to test

- CSP
- [ ] before this PR: log in Gmail with a `@gmail.com` account, onboarding iframe is not displayed.
- [ ] after this PR: log in Gmail with a `@gmail.com` account, onboarding iframe is displayed

- Protocol Handler
In the Gmail dev tool with the Mixmax contex console:
- [ ] ~`fetch('chrome-extension://ocpljaamllnldhepankaeljmeeeghnid/manifest.json', { mode: 'no-cors' }).then(console.log)` response is `net::FAILED`~
- [ ] ~`fetch('chrome-extension://ocpljaamllnldhepankaeljmeeeghnid/src/iframeProxy/proxy.html', { mode: 'no-cors' }).then(console.log)`  response is `HTTP 200`~
- [ ] ~`fetch('chrome-extension://ocpljaamllnldhepankaeljmeeeghnid/src/iframeProxy/proxy.js', { mode: 'no-cors' }).then(console.log)`  response is `HTTP 200`~