### PR TITLE
fix: use chrome web store extension id everywhere

### DIFF
--- a/src/browser/chrome-extension.js
+++ b/src/browser/chrome-extension.js
@@ -30,7 +30,7 @@ const isWindowOrWebView = function (webContents) {
 }
 
 // Create or get manifest object from |srcDirectory|.
-const getManifestFromPath = function (chromeStoreExtensionId, srcDirectory) {
+const getManifestFromPath = function (extensionId, srcDirectory) {
   let manifest
   let manifestContent
 
@@ -50,12 +50,10 @@ const getManifestFromPath = function (chromeStoreExtensionId, srcDirectory) {
     throw parseError
   }
   if (!manifestNameMap[manifest.name]) {
-    const extensionId = generateExtensionIdFromName(manifest.name)
-    manifestMap[extensionId] = manifestNameMap[manifest.name] = manifestWSMap[chromeStoreExtensionId] = manifest
+    manifestMap[extensionId] = manifestNameMap[manifest.name] = manifestWSMap[extensionId] = manifest
     Object.assign(manifest, {
       srcDirectory: srcDirectory,
-      chromeStoreExtensionId,
-      extensionId: extensionId,
+      extensionId,
       // We can not use 'file://' directly because all resources in the extension
       // will be treated as relative to the root in Chrome.
       startPage: url.format({
@@ -259,7 +257,6 @@ const injectContentScripts = function (manifest) {
 
   try {
     const entry = {
-      chromeStoreExtensionId: manifest.chromeStoreExtensionId,
       extensionId: manifest.extensionId,
       extensionName: manifest.name,
       contentScripts: manifest.content_scripts.map(contentScriptToEntry)

--- a/src/renderer/injectors/content-scripts-injector.js
+++ b/src/renderer/injectors/content-scripts-injector.js
@@ -78,13 +78,15 @@ Object.keys(contentScripts).forEach(key => {
   const worldId = require('../isolated-worlds').getIsolatedWorldId(cs.extensionId)
 
   webFrame.setIsolatedWorldHumanReadableName(worldId, cs.extensionName)
-  webFrame.setIsolatedWorldSecurityOrigin(worldId, `chrome-extension://${cs.chromeStoreExtensionId}`)
+  webFrame.setIsolatedWorldSecurityOrigin(worldId, `${constants.EXTENSION_PROTOCOL}://${cs.extensionId}`)
 
   const getContentSecurityPolicy = () => ipcRenderer.sendSync('GET_CONTENTSECURITYPOLICY_SYNC');
   const contentSecurityPolicy = getContentSecurityPolicy();
   if (contentSecurityPolicy.policy) {
     webFrame.setIsolatedWorldContentSecurityPolicy(worldId, contentSecurityPolicy.policy);
   } else {
+    // Match Chromium kDefaultIsolatedWorldCSP_Secure
+    // https://cs.chromium.org/chromium/src/extensions/common/manifest_handlers/csp_info.cc?l=36
     webFrame.setIsolatedWorldContentSecurityPolicy(worldId, "script-src 'self'; object-src 'self'");
   }
 
@@ -95,7 +97,7 @@ Object.keys(contentScripts).forEach(key => {
       const { guestInstanceId, openerId } = process;
 
       // hardcoded gmelius extension id
-      const shouldUseNonNativeWinOpen = cs.chromeStoreExtensionId === 'dheionainndbbpoacpnopgmnihkcmnkl';
+      const shouldUseNonNativeWinOpen = cs.extensionId === 'dheionainndbbpoacpnopgmnihkcmnkl';
 
       require('../window-setup')(isolatedWorldWindow, ipcRenderer, guestInstanceId, openerId, shouldUseNonNativeWinOpen);
       // end workaround


### PR DESCRIPTION
Tried a first time to use the Chrome Web Store Extension ID [here]( https://github.com/getstation/electron-chrome-extension/commit/fd632b4fe76569217421de0c2a44d7a3872eb66f#diff-34c6d86d8877371cb3b144c871520a50R107) before revert [here](https://github.com/getstation/electron-chrome-extension/commit/8f8d37e13c47611ce9c8b184775a68fa52fc883d) for fix some errors on Mixmax's side.

This PR is the complete solution tested with Mixmax, Gmelius,  Clearbit, Mailtracker and Boomerang.

