### PR TITLE
👽️  Use `_linkedBinding` for electron common imports

### DIFF
--- a/src/browser/chrome-extension.js
+++ b/src/browser/chrome-extension.js
@@ -1,5 +1,5 @@
 const { app, ipcMain, webContents } = require('electron')
-const { getAllWebContents } = process.electronBinding('web_contents')
+const { getAllWebContents } = process._linkedBinding('electron_common_web_contents')
 const ChromeAPIHandler = require('./handlers');
 
 const { Buffer } = require('buffer')


### PR DESCRIPTION
Electron has removed the `electronBinding` api. This api is the
provided replacement. It was removed in pr electron/electron#24191